### PR TITLE
Bump org.springframework.boot:spring-boot-starter-parent, com.squareup.okhttp3:okhttp and com.fasterxml.jackson.core:jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>3.3.0</version>
     </parent>
     <name>java-getting-started</name>
 
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.4.1</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.5</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot), [com.squareup.okhttp3:okhttp](https://github.com/square/okhttp) and [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson). These dependencies needed to be updated together.
Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.2.RELEASE to 3.3.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-parent's releases</a>.</em></p>
<blockquote>
<h2>v3.3.0</h2>
<h2>:star: New Features</h2>
<ul>
<li>Add support for descriptions of record components in configuration metadata generation <a href="https://redirect.github.com/spring-projects/spring-boot/pull/29403">#29403</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>gradlew bootBuildImage fails with Podman on macOS Sonoma <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40871">#40871</a></li>
<li>Pulsar auth parameters don't properly encode JSON values <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40869">#40869</a></li>
<li>When using JPA and ImportTestcontainers, test context may fail to refresh due to &quot;Mapped port can only be obtained after the container is started&quot; <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40863">#40863</a></li>
<li>Default MIME mappings are not loaded unless additional mappings are configured <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40860">#40860</a></li>
<li>Starting from 3.2.x, <code>@SpyBean</code> is not able to initialise MongoRepository bean of the generic type <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40855">#40855</a></li>
<li>Auto-configuration ordering change breaks DocumentReference (in non-reactive MongoTemplate) when depending on mongodb-driver-reactivestreams <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40851">#40851</a></li>
<li>Neo4jReactiveDataAutoConfiguration creates incorrectly named bean <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40836">#40836</a></li>
<li>Image building fails during cleanup when bind mount has read-only content <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40799">#40799</a></li>
<li>Failure Analysis for InvalidConfigurationPropertyValueException is skipped when the property is not set <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40691">#40691</a></li>
<li>IllegalArgumentException can be thrown when running an uber jar on a shared drive <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40643">#40643</a></li>
<li>setReadTimeout can't be set via Reflective factory on JettyClientHttpRequestFactory <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40638">#40638</a></li>
<li>URISyntaxException is raised if the spring boot application is started in a location that contains invalid URI characters <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40616">#40616</a></li>
<li>resolveMainClassName fails when building with Gradle using Java 22 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40613">#40613</a></li>
<li>AnsiOutput.detectIfAnsiCapable broken on JDK22 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40609">#40609</a></li>
<li>Help information for spring init's build option has the wrong default <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40606">#40606</a></li>
<li>JarUrlConnection.getPermission() can throw NullPointerException if jarFileConnection is null <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40599">#40599</a></li>
<li>Whitespace is not correctly trimmed when generating configuration properties metadata from records <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40593">#40593</a></li>
<li>In some situations, the failure when the AOT-generated initializer cannot be loaded is less helpful than before <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40584">#40584</a></li>
<li>Properties binding eagerly creates superfluous maps <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40561">#40561</a></li>
<li>Configuring SSL bundle reload for non-file resource types causes errors that are difficult to diagnose <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40560">#40560</a></li>
<li>spring-boot-dependencies cannot be used with repositories that ban com.oracle.database.jdbc:ojdbc-bom <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40535">#40535</a></li>
<li>Buildpacks do not support Docker with containerd image store <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40526">#40526</a></li>
<li>SpringBootMockMvcBuilderCustomizer can crash cryptically while collecting data that it would have discarded anyway <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40517">#40517</a></li>
<li>Containers not shut down between tests when using .withReuse(true) but env. does not support reuse (e.g. CI builds) <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40509">#40509</a></li>
<li>CookieSameSiteSupplier influences session cookie <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40501">#40501</a></li>
<li><code>&lt;springProperty&gt;</code> and <code>&lt;springProfile&gt;</code> do not work in <code>&lt;include&gt;</code> after Logback upgrade <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40491">#40491</a></li>
<li>Runtime hint registration for property binding should not fail when parameter information is unavailable <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40486">#40486</a></li>
<li>ServiceLevelObjectiveBoundary properties cannot be bound in a native image application <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40483">#40483</a></li>
<li>server.error.include-binding-errors does not recognize MethodValidationResult exceptions <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40474">#40474</a></li>
<li>spring.data.redis.cluster.nodes and spring.data.redis.sentinel.nodes do not handle IPv6 addresses correctly <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40467">#40467</a></li>
<li>Using relative paths to describe the classpath in the error message from ResolveMainClassName hinders problem diagnosis <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40465">#40465</a></li>
<li>Jartools extract command doesn't extract all files from META-INF <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40456">#40456</a></li>
<li>Native image doesn't start and doesn't log anything if an environment post processor throws an exception <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40451">#40451</a></li>
<li>Unlike DataSourceAutoConfiguration, DevToolsDataSourceAutoConfiguration assumes that javax.sql.DataSource will always be available <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40441">#40441</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Improve graceful shutdown documentation to remove ambiguity <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40846">#40846</a></li>
<li>Document ways to opt out from immutable <code>@ConfigurationProperties</code> binding with single constructor <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40844">#40844</a></li>
<li>Document that a custom HttpMessageConverters bean can be used to reorder json message converters when needed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40839">#40839</a></li>
<li>Address ambiguity now that Testcontainers has two classes named KafkaContainer <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40756">#40756</a></li>
<li>Publish API documentation for Spring Boot's Kotlin APIs <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40692">#40692</a></li>
<li>Fix typo in features doc <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40631">#40631</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/a25e1ebe41bc02c5e7341ed1464d61c496cffe7c"><code>a25e1eb</code></a> Release v3.3.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/ed0a3fd90845ebfa6a851c7c5d712a0ba0dcaa69"><code>ed0a3fd</code></a> Update publish-to-sdkman job to make new candidates the default</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/42d6f2c7a85690a444c1555fea2d72f3576f6d0b"><code>42d6f2c</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/234e0fd1f395ed284cd8b4726c9b73d695c28b27"><code>234e0fd</code></a> Stop mark 3.2.x as the default SDKman release</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/226b900babb25112e0ef0dcb02e2c06ce18564dd"><code>226b900</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c857eb62d483865bc260ea1becab4bb456468772"><code>c857eb6</code></a> Fix SDKman &quot;make default&quot; step</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/13e13f91c09f5012eb3bc61d39455ae5d4b43eff"><code>13e13f9</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/a5ee37c5262270a8d6a0e898a441f35677310d59"><code>a5ee37c</code></a> Next development version (v3.2.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/dffdd6d67ca0f1b46cf2645439a3552fa6c5f5d2"><code>dffdd6d</code></a> Explicitly set SDKman's make-default to false</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/86c206a849b746127be234ec3febd5eac5fc357e"><code>86c206a</code></a> Merge branch '3.2.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v1.5.2.RELEASE...v3.3.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.squareup.okhttp3:okhttp` from 3.4.1 to 4.12.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/square/okhttp/blob/master/CHANGELOG.md">com.squareup.okhttp3:okhttp's changelog</a>.</em></p>
<blockquote>
<h1>Change Log</h1>
<h2>Version 4.x</h2>
<p>See <a href="https://square.github.io/okhttp/changelogs/changelog_4x/">4.x Change log</a> for the stable version changelogs.</p>
<h2>Version 5.0.0-alpha.14</h2>
<p><em>2024-04-17</em></p>
<ul>
<li>
<p>Breaking: Move coroutines extensions to okhttp3.coroutines. Previously this artifact shared the
<code>okhttp3</code> package name with our core module, which is incompatible with the Java Platform Module
System.</p>
</li>
<li>
<p>Fix in okhttp-coroutines: Publish a valid artifact. The coroutines JAR file in 5.0.0-alpha.13
was corrupt and should not be used.</p>
</li>
</ul>
<h2>Version 5.0.0-alpha.13</h2>
<p><em>2024-04-16</em></p>
<ul>
<li>
<p>Breaking: Tag unstable new APIs as <code>@ExperimentalOkHttpApi</code>. We intend to release OkHttp 5.0
without stabilizing these new APIs first.</p>
<p>Do not use these experimental APIs in modules that may be executed using a version of OkHttp
different from the version that the module was compiled with. Do not use them in published
libraries. Do not use them if you aren't willing to track changes to them.</p>
</li>
<li>
<p>Breaking: Drop support for Kotlin Multiplatform.</p>
<p>We planned to support multiplatform in OkHttp 5.0, but after building it, we weren't happy with
the implementation trade-offs. We can't use our HTTP client engine on Kotlin/JS, and we weren't
prepared to build a TLS API for Kotlin/Native.</p>
<p>We'd prefer a multiplatform HTTP client API that's backed by OkHttp on Android and JVM, and
other engines on other platforms. [Ktor] does this pretty well today!</p>
</li>
<li>
<p>Breaking: Use <code>kotlin.time.Duration</code> in APIs like <code>OkHttpClient.Builder.callTimeout()</code>. This
update also drops support for the <code>DurationUnit</code> functions introduced in earlier alpha releases
of OkHttp 5.</p>
</li>
<li>
<p>Breaking: Reorder the parameters in the Cache constructor that was introduced in 5.0.0-alpha.3.</p>
</li>
<li>
<p>New: <code>Request.Builder.cacheUrlOverride()</code> customizes the cache key used for a request. This can
be used to make canonical URLs for the cache that omit insignificant query parameters or other
irrelevant data.</p>
<p>This feature may be used with <code>POST</code> requests to cache their responses. In such cases the</p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/square/okhttp/commit/4984568367caaf359b82c452bd28b5e192824d1c"><code>4984568</code></a> Prepare for release 4.12.0.</li>
<li><a href="https://github.com/square/okhttp/commit/ea720d32b50d0055be26fa3e9b9cd03460d3e737"><code>ea720d3</code></a> [4.x] Add test for 103 handling (<a href="https://redirect.github.com/square/okhttp/issues/8055">#8055</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/a6e54bfd1b6c69884ea04e689cab31b7b6ab0506"><code>a6e54bf</code></a> Avoid hanging on takeHeaders (incorrect 103 handling) when response body is e...</li>
<li><a href="https://github.com/square/okhttp/commit/4190ca8a62196f0c2b57868066c72a6d3ba7b512"><code>4190ca8</code></a> [4.x] Bump okio to 3.6 (<a href="https://redirect.github.com/square/okhttp/issues/8052">#8052</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/9553f6dce95ca7b867d3fac34a474a1f1014288e"><code>9553f6d</code></a> [4.x] Fix bad merge (<a href="https://redirect.github.com/square/okhttp/issues/8053">#8053</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/cd581af7cbd452d4afd7598ddf0badf3352b906a"><code>cd581af</code></a> Handle certificate corruption (<a href="https://redirect.github.com/square/okhttp/issues/7982">#7982</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/708d89b9eaead6de2ea5a1b3aad1c2e8e8b77e05"><code>708d89b</code></a> Make Public Suffix Database failures permanent (<a href="https://redirect.github.com/square/okhttp/issues/7828">#7828</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/b147d282b3afc70ad2119f4fe5e48b61e1980b94"><code>b147d28</code></a> Fix for stalled streams (<a href="https://redirect.github.com/square/okhttp/issues/7801">#7801</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7818">#7818</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/f04809d513e0ee1b0060c4763de3b2c4e54c8cd9"><code>f04809d</code></a> [4.x] Fix websocket reconnect race condition (<a href="https://redirect.github.com/square/okhttp/issues/7815">#7815</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7817">#7817</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/07b5d820a3422e7f99d1ad81d857729a739d6540"><code>07b5d82</code></a> [4.x] Suppress removed (<a href="https://redirect.github.com/square/okhttp/issues/7953">#7953</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/square/okhttp/compare/parent-3.4.1...parent-4.12.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.7.5 to 2.17.1
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/FasterXML/jackson/commits">compare view</a></li>
</ul>
</details>
<br />
