### PR TITLE
Bump org.springframework.boot:spring-boot-starter-parent, com.squareup.okhttp3:okhttp, com.fasterxml.jackson.core:jackson-databind, commons-codec:commons-codec, org.webjars:jquery, org.webjars:jquery-ui and org.webjars:bootstrap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>3.3.0</version>
     </parent>
     <name>java-getting-started</name>
 
@@ -18,9 +18,9 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <webjars-bootstrap.version>3.3.6</webjars-bootstrap.version>
-        <webjars-jquery-ui.version>1.11.4</webjars-jquery-ui.version>
-        <webjars-jquery.version>2.2.4</webjars-jquery.version>
+        <webjars-bootstrap.version>5.3.3</webjars-bootstrap.version>
+        <webjars-jquery-ui.version>1.13.3</webjars-jquery-ui.version>
+        <webjars-jquery.version>3.7.1</webjars-jquery.version>
         <thymeleaf.version>3.0.2.RELEASE</thymeleaf.version>
     </properties>
 
@@ -52,17 +52,17 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.4.1</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.5</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot), [com.squareup.okhttp3:okhttp](https://github.com/square/okhttp), [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson), [commons-codec:commons-codec](https://github.com/apache/commons-codec), [org.webjars:jquery](https://github.com/webjars/jquery), [org.webjars:jquery-ui](https://github.com/webjars/jquery-ui) and [org.webjars:bootstrap](https://github.com/webjars/bootstrap). These dependencies needed to be updated together.
Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.2.RELEASE to 3.3.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-parent's releases</a>.</em></p>
<blockquote>
<h2>v3.3.0</h2>
<h2>:star: New Features</h2>
<ul>
<li>Add support for descriptions of record components in configuration metadata generation <a href="https://redirect.github.com/spring-projects/spring-boot/pull/29403">#29403</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>gradlew bootBuildImage fails with Podman on macOS Sonoma <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40871">#40871</a></li>
<li>Pulsar auth parameters don't properly encode JSON values <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40869">#40869</a></li>
<li>When using JPA and ImportTestcontainers, test context may fail to refresh due to &quot;Mapped port can only be obtained after the container is started&quot; <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40863">#40863</a></li>
<li>Default MIME mappings are not loaded unless additional mappings are configured <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40860">#40860</a></li>
<li>Starting from 3.2.x, <code>@SpyBean</code> is not able to initialise MongoRepository bean of the generic type <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40855">#40855</a></li>
<li>Auto-configuration ordering change breaks DocumentReference (in non-reactive MongoTemplate) when depending on mongodb-driver-reactivestreams <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40851">#40851</a></li>
<li>Neo4jReactiveDataAutoConfiguration creates incorrectly named bean <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40836">#40836</a></li>
<li>Image building fails during cleanup when bind mount has read-only content <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40799">#40799</a></li>
<li>Failure Analysis for InvalidConfigurationPropertyValueException is skipped when the property is not set <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40691">#40691</a></li>
<li>IllegalArgumentException can be thrown when running an uber jar on a shared drive <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40643">#40643</a></li>
<li>setReadTimeout can't be set via Reflective factory on JettyClientHttpRequestFactory <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40638">#40638</a></li>
<li>URISyntaxException is raised if the spring boot application is started in a location that contains invalid URI characters <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40616">#40616</a></li>
<li>resolveMainClassName fails when building with Gradle using Java 22 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40613">#40613</a></li>
<li>AnsiOutput.detectIfAnsiCapable broken on JDK22 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40609">#40609</a></li>
<li>Help information for spring init's build option has the wrong default <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40606">#40606</a></li>
<li>JarUrlConnection.getPermission() can throw NullPointerException if jarFileConnection is null <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40599">#40599</a></li>
<li>Whitespace is not correctly trimmed when generating configuration properties metadata from records <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40593">#40593</a></li>
<li>In some situations, the failure when the AOT-generated initializer cannot be loaded is less helpful than before <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40584">#40584</a></li>
<li>Properties binding eagerly creates superfluous maps <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40561">#40561</a></li>
<li>Configuring SSL bundle reload for non-file resource types causes errors that are difficult to diagnose <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40560">#40560</a></li>
<li>spring-boot-dependencies cannot be used with repositories that ban com.oracle.database.jdbc:ojdbc-bom <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40535">#40535</a></li>
<li>Buildpacks do not support Docker with containerd image store <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40526">#40526</a></li>
<li>SpringBootMockMvcBuilderCustomizer can crash cryptically while collecting data that it would have discarded anyway <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40517">#40517</a></li>
<li>Containers not shut down between tests when using .withReuse(true) but env. does not support reuse (e.g. CI builds) <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40509">#40509</a></li>
<li>CookieSameSiteSupplier influences session cookie <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40501">#40501</a></li>
<li><code>&lt;springProperty&gt;</code> and <code>&lt;springProfile&gt;</code> do not work in <code>&lt;include&gt;</code> after Logback upgrade <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40491">#40491</a></li>
<li>Runtime hint registration for property binding should not fail when parameter information is unavailable <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40486">#40486</a></li>
<li>ServiceLevelObjectiveBoundary properties cannot be bound in a native image application <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40483">#40483</a></li>
<li>server.error.include-binding-errors does not recognize MethodValidationResult exceptions <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40474">#40474</a></li>
<li>spring.data.redis.cluster.nodes and spring.data.redis.sentinel.nodes do not handle IPv6 addresses correctly <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40467">#40467</a></li>
<li>Using relative paths to describe the classpath in the error message from ResolveMainClassName hinders problem diagnosis <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40465">#40465</a></li>
<li>Jartools extract command doesn't extract all files from META-INF <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40456">#40456</a></li>
<li>Native image doesn't start and doesn't log anything if an environment post processor throws an exception <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40451">#40451</a></li>
<li>Unlike DataSourceAutoConfiguration, DevToolsDataSourceAutoConfiguration assumes that javax.sql.DataSource will always be available <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40441">#40441</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Improve graceful shutdown documentation to remove ambiguity <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40846">#40846</a></li>
<li>Document ways to opt out from immutable <code>@ConfigurationProperties</code> binding with single constructor <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40844">#40844</a></li>
<li>Document that a custom HttpMessageConverters bean can be used to reorder json message converters when needed <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40839">#40839</a></li>
<li>Address ambiguity now that Testcontainers has two classes named KafkaContainer <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40756">#40756</a></li>
<li>Publish API documentation for Spring Boot's Kotlin APIs <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40692">#40692</a></li>
<li>Fix typo in features doc <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40631">#40631</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/a25e1ebe41bc02c5e7341ed1464d61c496cffe7c"><code>a25e1eb</code></a> Release v3.3.0</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/ed0a3fd90845ebfa6a851c7c5d712a0ba0dcaa69"><code>ed0a3fd</code></a> Update publish-to-sdkman job to make new candidates the default</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/42d6f2c7a85690a444c1555fea2d72f3576f6d0b"><code>42d6f2c</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/234e0fd1f395ed284cd8b4726c9b73d695c28b27"><code>234e0fd</code></a> Stop mark 3.2.x as the default SDKman release</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/226b900babb25112e0ef0dcb02e2c06ce18564dd"><code>226b900</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c857eb62d483865bc260ea1becab4bb456468772"><code>c857eb6</code></a> Fix SDKman &quot;make default&quot; step</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/13e13f91c09f5012eb3bc61d39455ae5d4b43eff"><code>13e13f9</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/a5ee37c5262270a8d6a0e898a441f35677310d59"><code>a5ee37c</code></a> Next development version (v3.2.7-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/dffdd6d67ca0f1b46cf2645439a3552fa6c5f5d2"><code>dffdd6d</code></a> Explicitly set SDKman's make-default to false</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/86c206a849b746127be234ec3febd5eac5fc357e"><code>86c206a</code></a> Merge branch '3.2.x'</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v1.5.2.RELEASE...v3.3.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.squareup.okhttp3:okhttp` from 3.4.1 to 4.12.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/square/okhttp/blob/master/CHANGELOG.md">com.squareup.okhttp3:okhttp's changelog</a>.</em></p>
<blockquote>
<h1>Change Log</h1>
<h2>Version 4.x</h2>
<p>See <a href="https://square.github.io/okhttp/changelogs/changelog_4x/">4.x Change log</a> for the stable version changelogs.</p>
<h2>Version 5.0.0-alpha.14</h2>
<p><em>2024-04-17</em></p>
<ul>
<li>
<p>Breaking: Move coroutines extensions to okhttp3.coroutines. Previously this artifact shared the
<code>okhttp3</code> package name with our core module, which is incompatible with the Java Platform Module
System.</p>
</li>
<li>
<p>Fix in okhttp-coroutines: Publish a valid artifact. The coroutines JAR file in 5.0.0-alpha.13
was corrupt and should not be used.</p>
</li>
</ul>
<h2>Version 5.0.0-alpha.13</h2>
<p><em>2024-04-16</em></p>
<ul>
<li>
<p>Breaking: Tag unstable new APIs as <code>@ExperimentalOkHttpApi</code>. We intend to release OkHttp 5.0
without stabilizing these new APIs first.</p>
<p>Do not use these experimental APIs in modules that may be executed using a version of OkHttp
different from the version that the module was compiled with. Do not use them in published
libraries. Do not use them if you aren't willing to track changes to them.</p>
</li>
<li>
<p>Breaking: Drop support for Kotlin Multiplatform.</p>
<p>We planned to support multiplatform in OkHttp 5.0, but after building it, we weren't happy with
the implementation trade-offs. We can't use our HTTP client engine on Kotlin/JS, and we weren't
prepared to build a TLS API for Kotlin/Native.</p>
<p>We'd prefer a multiplatform HTTP client API that's backed by OkHttp on Android and JVM, and
other engines on other platforms. [Ktor] does this pretty well today!</p>
</li>
<li>
<p>Breaking: Use <code>kotlin.time.Duration</code> in APIs like <code>OkHttpClient.Builder.callTimeout()</code>. This
update also drops support for the <code>DurationUnit</code> functions introduced in earlier alpha releases
of OkHttp 5.</p>
</li>
<li>
<p>Breaking: Reorder the parameters in the Cache constructor that was introduced in 5.0.0-alpha.3.</p>
</li>
<li>
<p>New: <code>Request.Builder.cacheUrlOverride()</code> customizes the cache key used for a request. This can
be used to make canonical URLs for the cache that omit insignificant query parameters or other
irrelevant data.</p>
<p>This feature may be used with <code>POST</code> requests to cache their responses. In such cases the</p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/square/okhttp/commit/4984568367caaf359b82c452bd28b5e192824d1c"><code>4984568</code></a> Prepare for release 4.12.0.</li>
<li><a href="https://github.com/square/okhttp/commit/ea720d32b50d0055be26fa3e9b9cd03460d3e737"><code>ea720d3</code></a> [4.x] Add test for 103 handling (<a href="https://redirect.github.com/square/okhttp/issues/8055">#8055</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/a6e54bfd1b6c69884ea04e689cab31b7b6ab0506"><code>a6e54bf</code></a> Avoid hanging on takeHeaders (incorrect 103 handling) when response body is e...</li>
<li><a href="https://github.com/square/okhttp/commit/4190ca8a62196f0c2b57868066c72a6d3ba7b512"><code>4190ca8</code></a> [4.x] Bump okio to 3.6 (<a href="https://redirect.github.com/square/okhttp/issues/8052">#8052</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/9553f6dce95ca7b867d3fac34a474a1f1014288e"><code>9553f6d</code></a> [4.x] Fix bad merge (<a href="https://redirect.github.com/square/okhttp/issues/8053">#8053</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/cd581af7cbd452d4afd7598ddf0badf3352b906a"><code>cd581af</code></a> Handle certificate corruption (<a href="https://redirect.github.com/square/okhttp/issues/7982">#7982</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/708d89b9eaead6de2ea5a1b3aad1c2e8e8b77e05"><code>708d89b</code></a> Make Public Suffix Database failures permanent (<a href="https://redirect.github.com/square/okhttp/issues/7828">#7828</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/b147d282b3afc70ad2119f4fe5e48b61e1980b94"><code>b147d28</code></a> Fix for stalled streams (<a href="https://redirect.github.com/square/okhttp/issues/7801">#7801</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7818">#7818</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/f04809d513e0ee1b0060c4763de3b2c4e54c8cd9"><code>f04809d</code></a> [4.x] Fix websocket reconnect race condition (<a href="https://redirect.github.com/square/okhttp/issues/7815">#7815</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7817">#7817</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/07b5d820a3422e7f99d1ad81d857729a739d6540"><code>07b5d82</code></a> [4.x] Suppress removed (<a href="https://redirect.github.com/square/okhttp/issues/7953">#7953</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/square/okhttp/compare/parent-3.4.1...parent-4.12.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.7.5 to 2.17.1
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/FasterXML/jackson/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `commons-codec:commons-codec` from 1.10 to 1.17.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/apache/commons-codec/blob/master/RELEASE-NOTES.txt">commons-codec:commons-codec's changelog</a>.</em></p>
<blockquote>
<h2>Apache Commons Codec 1.17.0 RELEASE NOTES</h2>
<p>The Apache Commons Codec component contains encoders and decoders for
various formats such as Base16, Base32, Base64, digest, and Hexadecimal. In addition to these
widely used encoders and decoders, the codec package also maintains a
collection of phonetic encoding utilities.</p>
<p>Feature and fix release. Requires a minimum of Java 8.</p>
<h2>New features</h2>
<ul>
<li>
<pre><code>        Add override org.apache.commons.codec.language.bm.Rule.PhonemeExpr.size(). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add support for Base64 custom alphabets [#266](https://github.com/apache/commons-codec/issues/266). Thanks to Chris Kocel, Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base64.Builder (allows custom alphabets). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base32.Builder (allows custom alphabets). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base64 support for a custom padding byte (like Base32). Thanks to Gary Gregory.
</code></pre>
</li>
</ul>
<h2>Fixed Bugs</h2>
<ul>
<li>CODEC-320:  Wrong output of DoubleMetaphone in 1.16.1. Thanks to Martin Frydl, Gary Gregory.</li>
<li>
<pre><code>        Optimize memory allocation in PhoneticEngine. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        BCodec and QCodec encode() methods throw UnsupportedCharsetException instead of EncoderException. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Set Javadoc link to latest Java API LTS version. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base32 constructor fails-fast with a NullPointerException if the custom alphabet array is null. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base32 constructor makes a defensive copy of the line separator array. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base64 constructor makes a defensive copy of the line separator array. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base64 constructor makes a defensive copy of a custom alphabet array. Thanks to Gary Gregory.
</code></pre>
</li>
</ul>
<h2>Changes</h2>
<ul>
<li>
<pre><code>        Bump org.apache.commons:commons-parent from 66 to 69 [#250](https://github.com/apache/commons-codec/issues/250), [#261](https://github.com/apache/commons-codec/issues/261). Thanks to Dependabot, Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Bump commons-io:commons-io from 2.15.1 to 2.16.1 [#258](https://github.com/apache/commons-codec/issues/258), [#265](https://github.com/apache/commons-codec/issues/265). Thanks to Dependabot, Gary Gregory.
</code></pre>
</li>
</ul>
<p>For complete information on Apache Commons Codec, including instructions on how to submit bug reports,
patches, or suggestions for improvement, see the Apache Commons Codec website:</p>
<p><a href="https://commons.apache.org/proper/commons-codec/">https://commons.apache.org/proper/commons-codec/</a></p>
<p>Download page: <a href="https://commons.apache.org/proper/commons-codec/download_codec.cgi">https://commons.apache.org/proper/commons-codec/download_codec.cgi</a></p>
<hr />
<h2>Apache Commons Codec 1.16.1 RELEASE NOTES</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/apache/commons-codec/commit/5d809fe3d729bde9b507a51d2b2ed659da053692"><code>5d809fe</code></a> Prepare for the next release candidate</li>
<li><a href="https://github.com/apache/commons-codec/commit/9a59c1c47b02ca795270b758c8d0591f5925b10f"><code>9a59c1c</code></a> Prepare for the next release candidate</li>
<li><a href="https://github.com/apache/commons-codec/commit/5f0cfd46c89df69b579f37562ff1eded7ffd4b5c"><code>5f0cfd4</code></a> Longer lines</li>
<li><a href="https://github.com/apache/commons-codec/commit/8714b5f62bb5fa5950aa5e8908bd0d8d3334dba5"><code>8714b5f</code></a> Remove dead comment</li>
<li><a href="https://github.com/apache/commons-codec/commit/c56b95664913aab406f768c66f9264481b28c1bb"><code>c56b956</code></a> Bullet-proof internals</li>
<li><a href="https://github.com/apache/commons-codec/commit/d2215d5dec3031f819c3bb514587d92a6aec8eff"><code>d2215d5</code></a> Base32 constructor fails-fast with a NullPointerException if the custom</li>
<li><a href="https://github.com/apache/commons-codec/commit/fcc70e6fa1271158dd8f3a90350fa2589713f257"><code>fcc70e6</code></a> Base32 constructor makes a defensive copy of the line separator</li>
<li><a href="https://github.com/apache/commons-codec/commit/ebe805a2730ad38886f9f04bd4d242e0a8c9caaa"><code>ebe805a</code></a> Base64 constructor makes a defensive copy of a custom alphabet array</li>
<li><a href="https://github.com/apache/commons-codec/commit/55043334240eb2a1838e37ea1c8a6e434d328fdf"><code>5504333</code></a> Better exception message</li>
<li><a href="https://github.com/apache/commons-codec/commit/c6c5f11eae145d8e8c655e622f0fc5dd74e6db2a"><code>c6c5f11</code></a> Base64 constructor makes a better defensive copy of the line separator</li>
<li>Additional commits viewable in <a href="https://github.com/apache/commons-codec/compare/1.10...rel/commons-codec-1.17.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:jquery` from 2.2.4 to 3.7.1
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/jquery/commit/af37ef239085d5447a713df682dbc113c5a35fb8"><code>af37ef2</code></a> [maven-release-plugin] prepare release jquery-3.7.1</li>
<li><a href="https://github.com/webjars/jquery/commit/8e974222aefe3554ab8ffa5abc47bfecb371b079"><code>8e97422</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/49d57c9378ade4c8d70083702c5df2262aa7efe6"><code>49d57c9</code></a> [maven-release-plugin] prepare release jquery-3.7.0</li>
<li><a href="https://github.com/webjars/jquery/commit/64857565d4b3edf185f8764e2b9c1b2cd0932eac"><code>6485756</code></a> bump to 3.7.0 - fixes <a href="https://redirect.github.com/webjars/jquery/issues/177">#177</a></li>
<li><a href="https://github.com/webjars/jquery/commit/7c10b2c28d34078db084794d64fb87af526e5d7d"><code>7c10b2c</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/d26a6055340f20c8d65483ed66924247a15e3f55"><code>d26a605</code></a> [maven-release-plugin] prepare release jquery-3.6.4</li>
<li><a href="https://github.com/webjars/jquery/commit/5a9bc2afa5e61ebef57d373bf643b466016bc971"><code>5a9bc2a</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/a2482fb41211bae411308ae803b8db181f1076e9"><code>a2482fb</code></a> [maven-release-plugin] prepare release jquery-3.6.3</li>
<li><a href="https://github.com/webjars/jquery/commit/b50d92d3f5219768b8e1e565d61f9bdc6f9ed615"><code>b50d92d</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/fa3077d763799475bd71cd5741ff9036b9cad3d9"><code>fa3077d</code></a> [maven-release-plugin] prepare release jquery-3.6.2</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/jquery/compare/jquery-2.2.4...jquery-3.7.1">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:jquery-ui` from 1.11.4 to 1.13.3
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/jquery-ui/commit/3d6ccf5bc8b60fc66681f84fc6ffa3296bb0bfa0"><code>3d6ccf5</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.3</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/0c24384b0aa450ed8cdf8f853849034d97b067fa"><code>0c24384</code></a> bump plugins</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/6153259b12c7d56594b061185c0bb1cde523abcb"><code>6153259</code></a> Merge pull request <a href="https://redirect.github.com/webjars/jquery-ui/issues/34">#34</a> from hboutemy/patch-1</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/a2b3e03fa94eafc12d02beab721a6a1b220762e2"><code>a2b3e03</code></a> make build reproducible</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/4338afd6b3c3eb322430a1127af0c0e7c4459ba2"><code>4338afd</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/c948c3e3d509c25ce5dbabe627070962e2dab880"><code>c948c3e</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.2</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/60fc82ddfe73abd5879d668761e790a80511ad64"><code>60fc82d</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/771c5932fb059acde881827c38a83fdb7fb64b76"><code>771c593</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.1</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/fe0278ed55d2f5a54c79d34cf8ac45d65cbe483b"><code>fe0278e</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/97d5ac9609b52283cca876f734b77012e0860ef3"><code>97d5ac9</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.0</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/jquery-ui/compare/jquery-ui-1.11.4...jquery-ui-1.13.3">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:bootstrap` from 3.3.6 to 5.3.3
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/bootstrap/commit/42c06f48edf15c9feb87fe5ebbb227c0954ccbf2"><code>42c06f4</code></a> [maven-release-plugin] prepare release bootstrap-5.3.3</li>
<li><a href="https://github.com/webjars/bootstrap/commit/514b36a8d8cadc0ebbbd0278add9e4bbb8295a1f"><code>514b36a</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/c9d4100edc94f480e4078c13487597e24a8bc772"><code>c9d4100</code></a> [maven-release-plugin] prepare release bootstrap-5.3.2</li>
<li><a href="https://github.com/webjars/bootstrap/commit/532bab6cb872200ec52029826516a5832b4e7e98"><code>532bab6</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/f277e83b23fa1fc3e64ceda91d4fc2a95c0fdb1c"><code>f277e83</code></a> [maven-release-plugin] prepare release bootstrap-5.3.1</li>
<li><a href="https://github.com/webjars/bootstrap/commit/f131846afaee6556af7a54b2e4108663097d3de8"><code>f131846</code></a> bump plugins</li>
<li><a href="https://github.com/webjars/bootstrap/commit/21c54643dc34b6dd21995756cc6747781439a3f8"><code>21c5464</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/33b061d6e7f0d88197715a64b6770ddffa09e721"><code>33b061d</code></a> [maven-release-plugin] prepare release bootstrap-5.3.0</li>
<li><a href="https://github.com/webjars/bootstrap/commit/5727ad428908faeafb68e95aff8a23b493c26b57"><code>5727ad4</code></a> bump to 5.3.0 - fixes <a href="https://redirect.github.com/webjars/bootstrap/issues/183">#183</a></li>
<li><a href="https://github.com/webjars/bootstrap/commit/bf23d3119c61b4b2ac199fe0fd73cdcbb68a8ba6"><code>bf23d31</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/bootstrap/compare/bootstrap-3.3.6...bootstrap-5.3.3">compare view</a></li>
</ul>
</details>
<br />
