### PR TITLE
Dependencies - Version Update - 2024-06-26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>3.3.1</version>
     </parent>
     <name>java-getting-started</name>
 
@@ -18,9 +18,9 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <webjars-bootstrap.version>3.3.6</webjars-bootstrap.version>
-        <webjars-jquery-ui.version>1.11.4</webjars-jquery-ui.version>
-        <webjars-jquery.version>2.2.4</webjars-jquery.version>
+        <webjars-bootstrap.version>5.3.3</webjars-bootstrap.version>
+        <webjars-jquery-ui.version>1.13.3</webjars-jquery-ui.version>
+        <webjars-jquery.version>3.7.1</webjars-jquery.version>
         <thymeleaf.version>3.0.2.RELEASE</thymeleaf.version>
     </properties>
 
@@ -57,12 +57,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.5</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.3.7.RELEASE</version>
+            <version>6.1.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot), [com.squareup.okhttp3:okhttp](https://github.com/square/okhttp), [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson), [commons-codec:commons-codec](https://github.com/apache/commons-codec), [org.webjars:jquery](https://github.com/webjars/jquery), [org.webjars:jquery-ui](https://github.com/webjars/jquery-ui), [org.webjars:bootstrap](https://github.com/webjars/bootstrap) and [org.springframework:spring-web](https://github.com/spring-projects/spring-framework). These dependencies needed to be updated together.
Updates `org.springframework.boot:spring-boot-starter-parent` from 1.5.2.RELEASE to 3.3.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-boot/releases">org.springframework.boot:spring-boot-starter-parent's releases</a>.</em></p>
<blockquote>
<h2>v3.3.1</h2>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>SQL Server JDBC URL is malformed after adding org.springframework.boot.jdbc.parameters label <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41169">#41169</a></li>
<li>Git instant properties cannot be coerced following git-commit-id Maven plugin upgrade <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41152">#41152</a></li>
<li>Excluding status code from DefaultErrorAttributes throws NPE <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41141">#41141</a></li>
<li>Spring Boot remote restart with devtools causes 'factory already defined' Tomcat error when running with 'java -jar' <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41107">#41107</a></li>
<li>MongoHealthIndicator not compliant with Mongo stable API with strict setting <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41104">#41104</a></li>
<li>Service connection for bitnami mongodb fails to connect <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41097">#41097</a></li>
<li>Image building requires builder to specify a stack <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41091">#41091</a></li>
<li>DataSourceProperties fail to bind if java.sql module isn't included <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41084">#41084</a></li>
<li>AOT causes Logback configuration error when using include <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41081">#41081</a></li>
<li>Image building hangs when builder and buildpack are configured <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41049">#41049</a></li>
<li>IllegalArgumentException when trying to use Tomcat's HttpNio2Protocol with Spring Boot-configured SSL <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41010">#41010</a></li>
<li>Uber jar fails to start when it contains a dependency with Multi-Release: true in its manifest and unexpected file entries in META-INF/versions <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41006">#41006</a></li>
<li>JSP-related resources may not be found in an executable war file when using Jetty <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40996">#40996</a></li>
<li>The value of the tomcat.threads.config.max metric is always -1, irrespective of the configured maximum number of threads <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40957">#40957</a></li>
<li>The auto-configured reactiveNeo4jTransactionManager may cause a failure due to multiple TransactionManager beans <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40953">#40953</a></li>
<li>Application fails to start when server.tomcat.threads.max &lt; 10 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40945">#40945</a></li>
<li>SBOM actuator endpoint doesn't work in a native image <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40939">#40939</a></li>
<li>Starter parent applies its configuration of the CycloneDX Maven plugin too broadly <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40927">#40927</a></li>
<li>buildInfo does not work with Gradle 8.7 or later when the configuration cache is enabled <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40924">#40924</a></li>
<li>Prometheus Exemplars are missing from _count <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40904">#40904</a></li>
<li>Extract fails due to a duplicate entry when BOOT-INF/classes contains a directory that's also present in the root of the jar <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40903">#40903</a></li>
<li>sbom is not available to the actuator endpoint when using bootRun or bootWar <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40890">#40890</a></li>
<li>A newline character is missing from the start of the default banner <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40889">#40889</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Fix links to Spring AMQP's javadoc <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41144">#41144</a></li>
<li>Document more precisely how a Container's Docker image name is used to find the matching service connection <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41123">#41123</a></li>
<li>Cross-link to the CDS how-to guide <a href="https://redirect.github.com/spring-projects/spring-boot/pull/41118">#41118</a></li>
<li>Fix typos in javadoc of MockServerRestClientCustomizer and MockServerRestTemplateCustomizer <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41065">#41065</a></li>
<li>Improve readability when listing three pillars of observability <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41064">#41064</a></li>
<li>Add CDS training run configuration documentation <a href="https://redirect.github.com/spring-projects/spring-boot/pull/41045">#41045</a></li>
<li>Document the need to switch to io.micrometer:micrometer-registry-prometheus-simpleclient to use the Prometheus push gateway <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40993">#40993</a></li>
<li>Improve consistency of documentation guidelines for packaging and running applications <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40977">#40977</a></li>
<li>Fix typos in method names and javadoc <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40976">#40976</a></li>
<li>Replace hard-coded links to Micrometer in documentation <a href="https://redirect.github.com/spring-projects/spring-boot/pull/40967">#40967</a></li>
<li>Add Kotlin example for <code>@Testcontainers</code> <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40943">#40943</a></li>
<li>Fix various minor inconsistencies of the documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40942">#40942</a></li>
<li>Warn in the documentation that spring.profiles.group can only be used in non-profile-specific documents <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40941">#40941</a></li>
<li>Broken Micrometer links in documentation <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40916">#40916</a></li>
<li>Document Buildpacks CDS and Spring AOT support <a href="https://redirect.github.com/spring-projects/spring-boot/issues/40762">#40762</a></li>
</ul>
<h2>:hammer: Dependency Upgrades</h2>
<ul>
<li>Upgrade to Byte Buddy 1.14.17 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41066">#41066</a></li>
<li>Upgrade to FreeMarker 2.3.33 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41067">#41067</a></li>
<li>Upgrade to HSQLDB 2.7.3 <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41068">#41068</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-boot/commit/586499db56afc755a1e5e623afc5bb636c601562"><code>586499d</code></a> Release v3.3.1</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/3ef5254d93939f10b521b13920d32e30cb179873"><code>3ef5254</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/b65aae4530931f6977d86d62e895460a0fcbe1c4"><code>b65aae4</code></a> Next development version (v3.2.8-SNAPSHOT)</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/8e405c02245ae25c632c7c97c4a18b380e0e2fd1"><code>8e405c0</code></a> Merge branch '3.2.x'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/c2f21e9fcd282b1e76b0614a4c5034717fd4e3d7"><code>c2f21e9</code></a> Don't execute <a href="https://github.com/DockerComposeTests"><code>@​DockerComposeTests</code></a> if docker is not running</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/e7ffeb3dc94e0430c013f8200f76eaa5074e6131"><code>e7ffeb3</code></a> Use Tomcat's new setter for max queue size</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/fb9d779aeb81c5942b6a16d3f2537109de4f2a39"><code>fb9d779</code></a> Merge pull request <a href="https://redirect.github.com/spring-projects/spring-boot/issues/41162">#41162</a> from mateusscheper</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/955fe1868b441add8cf1fde55fdf35a6dffc6db6"><code>955fe18</code></a> Polish 'Improve readability of documentation'</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/cf8ed63dde2630b99250a84d045034238dbd4d62"><code>cf8ed63</code></a> Improve readability of documentation</li>
<li><a href="https://github.com/spring-projects/spring-boot/commit/6c34c02acfb37c20f1814705ab4ea927a75b0f1f"><code>6c34c02</code></a> Improving readability</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-boot/compare/v1.5.2.RELEASE...v3.3.1">compare view</a></li>
</ul>
</details>
<br />

Updates `com.squareup.okhttp3:okhttp` from 3.4.1 to 4.12.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/square/okhttp/blob/master/CHANGELOG.md">com.squareup.okhttp3:okhttp's changelog</a>.</em></p>
<blockquote>
<h1>Change Log</h1>
<h2>Version 4.x</h2>
<p>See <a href="https://square.github.io/okhttp/changelogs/changelog_4x/">4.x Change log</a> for the stable version changelogs.</p>
<h2>Version 5.0.0-alpha.14</h2>
<p><em>2024-04-17</em></p>
<ul>
<li>
<p>Breaking: Move coroutines extensions to okhttp3.coroutines. Previously this artifact shared the
<code>okhttp3</code> package name with our core module, which is incompatible with the Java Platform Module
System.</p>
</li>
<li>
<p>Fix in okhttp-coroutines: Publish a valid artifact. The coroutines JAR file in 5.0.0-alpha.13
was corrupt and should not be used.</p>
</li>
</ul>
<h2>Version 5.0.0-alpha.13</h2>
<p><em>2024-04-16</em></p>
<ul>
<li>
<p>Breaking: Tag unstable new APIs as <code>@ExperimentalOkHttpApi</code>. We intend to release OkHttp 5.0
without stabilizing these new APIs first.</p>
<p>Do not use these experimental APIs in modules that may be executed using a version of OkHttp
different from the version that the module was compiled with. Do not use them in published
libraries. Do not use them if you aren't willing to track changes to them.</p>
</li>
<li>
<p>Breaking: Drop support for Kotlin Multiplatform.</p>
<p>We planned to support multiplatform in OkHttp 5.0, but after building it, we weren't happy with
the implementation trade-offs. We can't use our HTTP client engine on Kotlin/JS, and we weren't
prepared to build a TLS API for Kotlin/Native.</p>
<p>We'd prefer a multiplatform HTTP client API that's backed by OkHttp on Android and JVM, and
other engines on other platforms. [Ktor] does this pretty well today!</p>
</li>
<li>
<p>Breaking: Use <code>kotlin.time.Duration</code> in APIs like <code>OkHttpClient.Builder.callTimeout()</code>. This
update also drops support for the <code>DurationUnit</code> functions introduced in earlier alpha releases
of OkHttp 5.</p>
</li>
<li>
<p>Breaking: Reorder the parameters in the Cache constructor that was introduced in 5.0.0-alpha.3.</p>
</li>
<li>
<p>New: <code>Request.Builder.cacheUrlOverride()</code> customizes the cache key used for a request. This can
be used to make canonical URLs for the cache that omit insignificant query parameters or other
irrelevant data.</p>
<p>This feature may be used with <code>POST</code> requests to cache their responses. In such cases the</p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/square/okhttp/commit/4984568367caaf359b82c452bd28b5e192824d1c"><code>4984568</code></a> Prepare for release 4.12.0.</li>
<li><a href="https://github.com/square/okhttp/commit/ea720d32b50d0055be26fa3e9b9cd03460d3e737"><code>ea720d3</code></a> [4.x] Add test for 103 handling (<a href="https://redirect.github.com/square/okhttp/issues/8055">#8055</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/a6e54bfd1b6c69884ea04e689cab31b7b6ab0506"><code>a6e54bf</code></a> Avoid hanging on takeHeaders (incorrect 103 handling) when response body is e...</li>
<li><a href="https://github.com/square/okhttp/commit/4190ca8a62196f0c2b57868066c72a6d3ba7b512"><code>4190ca8</code></a> [4.x] Bump okio to 3.6 (<a href="https://redirect.github.com/square/okhttp/issues/8052">#8052</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/9553f6dce95ca7b867d3fac34a474a1f1014288e"><code>9553f6d</code></a> [4.x] Fix bad merge (<a href="https://redirect.github.com/square/okhttp/issues/8053">#8053</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/cd581af7cbd452d4afd7598ddf0badf3352b906a"><code>cd581af</code></a> Handle certificate corruption (<a href="https://redirect.github.com/square/okhttp/issues/7982">#7982</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/708d89b9eaead6de2ea5a1b3aad1c2e8e8b77e05"><code>708d89b</code></a> Make Public Suffix Database failures permanent (<a href="https://redirect.github.com/square/okhttp/issues/7828">#7828</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/b147d282b3afc70ad2119f4fe5e48b61e1980b94"><code>b147d28</code></a> Fix for stalled streams (<a href="https://redirect.github.com/square/okhttp/issues/7801">#7801</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7818">#7818</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/f04809d513e0ee1b0060c4763de3b2c4e54c8cd9"><code>f04809d</code></a> [4.x] Fix websocket reconnect race condition (<a href="https://redirect.github.com/square/okhttp/issues/7815">#7815</a>) (<a href="https://redirect.github.com/square/okhttp/issues/7817">#7817</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/07b5d820a3422e7f99d1ad81d857729a739d6540"><code>07b5d82</code></a> [4.x] Suppress removed (<a href="https://redirect.github.com/square/okhttp/issues/7953">#7953</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/square/okhttp/compare/parent-3.4.1...parent-4.12.0">compare view</a></li>
</ul>
</details>
<br />

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.7.5 to 2.17.1
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/FasterXML/jackson/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `commons-codec:commons-codec` from 1.10 to 1.17.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/apache/commons-codec/blob/master/RELEASE-NOTES.txt">commons-codec:commons-codec's changelog</a>.</em></p>
<blockquote>
<h2>Apache Commons Codec 1.17.0 RELEASE NOTES</h2>
<p>The Apache Commons Codec component contains encoders and decoders for
various formats such as Base16, Base32, Base64, digest, and Hexadecimal. In addition to these
widely used encoders and decoders, the codec package also maintains a
collection of phonetic encoding utilities.</p>
<p>Feature and fix release. Requires a minimum of Java 8.</p>
<h2>New features</h2>
<ul>
<li>
<pre><code>        Add override org.apache.commons.codec.language.bm.Rule.PhonemeExpr.size(). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add support for Base64 custom alphabets [#266](https://github.com/apache/commons-codec/issues/266). Thanks to Chris Kocel, Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base64.Builder (allows custom alphabets). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base32.Builder (allows custom alphabets). Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Add Base64 support for a custom padding byte (like Base32). Thanks to Gary Gregory.
</code></pre>
</li>
</ul>
<h2>Fixed Bugs</h2>
<ul>
<li>CODEC-320:  Wrong output of DoubleMetaphone in 1.16.1. Thanks to Martin Frydl, Gary Gregory.</li>
<li>
<pre><code>        Optimize memory allocation in PhoneticEngine. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        BCodec and QCodec encode() methods throw UnsupportedCharsetException instead of EncoderException. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Set Javadoc link to latest Java API LTS version. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base32 constructor fails-fast with a NullPointerException if the custom alphabet array is null. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base32 constructor makes a defensive copy of the line separator array. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base64 constructor makes a defensive copy of the line separator array. Thanks to Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Base64 constructor makes a defensive copy of a custom alphabet array. Thanks to Gary Gregory.
</code></pre>
</li>
</ul>
<h2>Changes</h2>
<ul>
<li>
<pre><code>        Bump org.apache.commons:commons-parent from 66 to 69 [#250](https://github.com/apache/commons-codec/issues/250), [#261](https://github.com/apache/commons-codec/issues/261). Thanks to Dependabot, Gary Gregory.
</code></pre>
</li>
<li>
<pre><code>        Bump commons-io:commons-io from 2.15.1 to 2.16.1 [#258](https://github.com/apache/commons-codec/issues/258), [#265](https://github.com/apache/commons-codec/issues/265). Thanks to Dependabot, Gary Gregory.
</code></pre>
</li>
</ul>
<p>For complete information on Apache Commons Codec, including instructions on how to submit bug reports,
patches, or suggestions for improvement, see the Apache Commons Codec website:</p>
<p><a href="https://commons.apache.org/proper/commons-codec/">https://commons.apache.org/proper/commons-codec/</a></p>
<p>Download page: <a href="https://commons.apache.org/proper/commons-codec/download_codec.cgi">https://commons.apache.org/proper/commons-codec/download_codec.cgi</a></p>
<hr />
<h2>Apache Commons Codec 1.16.1 RELEASE NOTES</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/apache/commons-codec/commit/5d809fe3d729bde9b507a51d2b2ed659da053692"><code>5d809fe</code></a> Prepare for the next release candidate</li>
<li><a href="https://github.com/apache/commons-codec/commit/9a59c1c47b02ca795270b758c8d0591f5925b10f"><code>9a59c1c</code></a> Prepare for the next release candidate</li>
<li><a href="https://github.com/apache/commons-codec/commit/5f0cfd46c89df69b579f37562ff1eded7ffd4b5c"><code>5f0cfd4</code></a> Longer lines</li>
<li><a href="https://github.com/apache/commons-codec/commit/8714b5f62bb5fa5950aa5e8908bd0d8d3334dba5"><code>8714b5f</code></a> Remove dead comment</li>
<li><a href="https://github.com/apache/commons-codec/commit/c56b95664913aab406f768c66f9264481b28c1bb"><code>c56b956</code></a> Bullet-proof internals</li>
<li><a href="https://github.com/apache/commons-codec/commit/d2215d5dec3031f819c3bb514587d92a6aec8eff"><code>d2215d5</code></a> Base32 constructor fails-fast with a NullPointerException if the custom</li>
<li><a href="https://github.com/apache/commons-codec/commit/fcc70e6fa1271158dd8f3a90350fa2589713f257"><code>fcc70e6</code></a> Base32 constructor makes a defensive copy of the line separator</li>
<li><a href="https://github.com/apache/commons-codec/commit/ebe805a2730ad38886f9f04bd4d242e0a8c9caaa"><code>ebe805a</code></a> Base64 constructor makes a defensive copy of a custom alphabet array</li>
<li><a href="https://github.com/apache/commons-codec/commit/55043334240eb2a1838e37ea1c8a6e434d328fdf"><code>5504333</code></a> Better exception message</li>
<li><a href="https://github.com/apache/commons-codec/commit/c6c5f11eae145d8e8c655e622f0fc5dd74e6db2a"><code>c6c5f11</code></a> Base64 constructor makes a better defensive copy of the line separator</li>
<li>Additional commits viewable in <a href="https://github.com/apache/commons-codec/compare/1.10...rel/commons-codec-1.17.0">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:jquery` from 2.2.4 to 3.7.1
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/jquery/commit/af37ef239085d5447a713df682dbc113c5a35fb8"><code>af37ef2</code></a> [maven-release-plugin] prepare release jquery-3.7.1</li>
<li><a href="https://github.com/webjars/jquery/commit/8e974222aefe3554ab8ffa5abc47bfecb371b079"><code>8e97422</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/49d57c9378ade4c8d70083702c5df2262aa7efe6"><code>49d57c9</code></a> [maven-release-plugin] prepare release jquery-3.7.0</li>
<li><a href="https://github.com/webjars/jquery/commit/64857565d4b3edf185f8764e2b9c1b2cd0932eac"><code>6485756</code></a> bump to 3.7.0 - fixes <a href="https://redirect.github.com/webjars/jquery/issues/177">#177</a></li>
<li><a href="https://github.com/webjars/jquery/commit/7c10b2c28d34078db084794d64fb87af526e5d7d"><code>7c10b2c</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/d26a6055340f20c8d65483ed66924247a15e3f55"><code>d26a605</code></a> [maven-release-plugin] prepare release jquery-3.6.4</li>
<li><a href="https://github.com/webjars/jquery/commit/5a9bc2afa5e61ebef57d373bf643b466016bc971"><code>5a9bc2a</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/a2482fb41211bae411308ae803b8db181f1076e9"><code>a2482fb</code></a> [maven-release-plugin] prepare release jquery-3.6.3</li>
<li><a href="https://github.com/webjars/jquery/commit/b50d92d3f5219768b8e1e565d61f9bdc6f9ed615"><code>b50d92d</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery/commit/fa3077d763799475bd71cd5741ff9036b9cad3d9"><code>fa3077d</code></a> [maven-release-plugin] prepare release jquery-3.6.2</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/jquery/compare/jquery-2.2.4...jquery-3.7.1">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:jquery-ui` from 1.11.4 to 1.13.3
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/jquery-ui/commit/3d6ccf5bc8b60fc66681f84fc6ffa3296bb0bfa0"><code>3d6ccf5</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.3</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/0c24384b0aa450ed8cdf8f853849034d97b067fa"><code>0c24384</code></a> bump plugins</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/6153259b12c7d56594b061185c0bb1cde523abcb"><code>6153259</code></a> Merge pull request <a href="https://redirect.github.com/webjars/jquery-ui/issues/34">#34</a> from hboutemy/patch-1</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/a2b3e03fa94eafc12d02beab721a6a1b220762e2"><code>a2b3e03</code></a> make build reproducible</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/4338afd6b3c3eb322430a1127af0c0e7c4459ba2"><code>4338afd</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/c948c3e3d509c25ce5dbabe627070962e2dab880"><code>c948c3e</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.2</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/60fc82ddfe73abd5879d668761e790a80511ad64"><code>60fc82d</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/771c5932fb059acde881827c38a83fdb7fb64b76"><code>771c593</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.1</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/fe0278ed55d2f5a54c79d34cf8ac45d65cbe483b"><code>fe0278e</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/jquery-ui/commit/97d5ac9609b52283cca876f734b77012e0860ef3"><code>97d5ac9</code></a> [maven-release-plugin] prepare release jquery-ui-1.13.0</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/jquery-ui/compare/jquery-ui-1.11.4...jquery-ui-1.13.3">compare view</a></li>
</ul>
</details>
<br />

Updates `org.webjars:bootstrap` from 3.3.6 to 5.3.3
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webjars/bootstrap/commit/42c06f48edf15c9feb87fe5ebbb227c0954ccbf2"><code>42c06f4</code></a> [maven-release-plugin] prepare release bootstrap-5.3.3</li>
<li><a href="https://github.com/webjars/bootstrap/commit/514b36a8d8cadc0ebbbd0278add9e4bbb8295a1f"><code>514b36a</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/c9d4100edc94f480e4078c13487597e24a8bc772"><code>c9d4100</code></a> [maven-release-plugin] prepare release bootstrap-5.3.2</li>
<li><a href="https://github.com/webjars/bootstrap/commit/532bab6cb872200ec52029826516a5832b4e7e98"><code>532bab6</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/f277e83b23fa1fc3e64ceda91d4fc2a95c0fdb1c"><code>f277e83</code></a> [maven-release-plugin] prepare release bootstrap-5.3.1</li>
<li><a href="https://github.com/webjars/bootstrap/commit/f131846afaee6556af7a54b2e4108663097d3de8"><code>f131846</code></a> bump plugins</li>
<li><a href="https://github.com/webjars/bootstrap/commit/21c54643dc34b6dd21995756cc6747781439a3f8"><code>21c5464</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li><a href="https://github.com/webjars/bootstrap/commit/33b061d6e7f0d88197715a64b6770ddffa09e721"><code>33b061d</code></a> [maven-release-plugin] prepare release bootstrap-5.3.0</li>
<li><a href="https://github.com/webjars/bootstrap/commit/5727ad428908faeafb68e95aff8a23b493c26b57"><code>5727ad4</code></a> bump to 5.3.0 - fixes <a href="https://redirect.github.com/webjars/bootstrap/issues/183">#183</a></li>
<li><a href="https://github.com/webjars/bootstrap/commit/bf23d3119c61b4b2ac199fe0fd73cdcbb68a8ba6"><code>bf23d31</code></a> [maven-release-plugin] prepare for next development iteration</li>
<li>Additional commits viewable in <a href="https://github.com/webjars/bootstrap/compare/bootstrap-3.3.6...bootstrap-5.3.3">compare view</a></li>
</ul>
</details>
<br />

Updates `org.springframework:spring-web` from 4.3.7.RELEASE to 6.1.10
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/spring-projects/spring-framework/releases">org.springframework:spring-web's releases</a>.</em></p>
<blockquote>
<h2>v6.1.10</h2>
<h2>:star: New Features</h2>
<ul>
<li>Defensive <code>PersistenceExceptionTranslator</code> bean retrieval in <code>PersistenceExceptionTranslationInterceptor</code> on shutdown <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33067">#33067</a></li>
<li>Support all &quot;connection reset&quot; exception phrases in <code>DisconnectedClientHelper</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33064">#33064</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Duplicate observations recorded with RestClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33068">#33068</a></li>
<li>WebFlux validation requires Servlet API since Spring Framework 6.1.3 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33043">#33043</a></li>
<li>No qualifying bean of type 'java.lang.String' in case of accidental <code>@Autowired</code> <code>@Bean</code> method with <code>@Value</code> parameter <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33030">#33030</a></li>
<li>ConfigurationClassEnhancer doesn't not use correct ClassLoader when called multiple times <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33024">#33024</a></li>
</ul>
<h2>:notebook_with_decorative_cover: Documentation</h2>
<ul>
<li>Typo in Annotation-driven Listener Endpoints section of Spring Framework documentation <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33050">#33050</a></li>
<li>Container Extension Points section of Spring Framework documentation refer to the wrong property name <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33037">#33037</a></li>
<li>Fix typo in comment <a href="https://redirect.github.com/spring-projects/spring-framework/pull/33036">#33036</a></li>
<li>Incorrect constructor details in the javadoc for ApplicationContextEvent <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33032">#33032</a></li>
</ul>
<h2>:heart: Contributors</h2>
<p>Thank you to all the contributors who worked on this release:</p>
<p><a href="https://github.com/tafjwr"><code>@​tafjwr</code></a></p>
<h2>v6.1.9</h2>
<h2>:star: New Features</h2>
<ul>
<li>CRaC: ignore checkpointOnRefresh afterRestore <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32978">#32978</a></li>
<li>Add missing hints for Hibernate <code>@TenantId</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32967">#32967</a></li>
<li>AnnotationUtils performance degrades with deep stacks <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32921">#32921</a></li>
<li>Missing hints for Hibernate generators <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32842">#32842</a></li>
<li>AbstractAutoProxyCreator#determineBeanType can trigger bean initialization at build time for aspects implementing Ordered <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32230">#32230</a></li>
</ul>
<h2>:lady_beetle: Bug Fixes</h2>
<ul>
<li>Behaviour change in ScheduledAnnotationBeanPostProcessor: canceling scheduled tasks on ContextClosedEvent v6.0 -&gt; v6.1 <a href="https://redirect.github.com/spring-projects/spring-framework/issues/33009">#33009</a></li>
<li>ContentCachingRequestWrapper  may allocate too much memory <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32987">#32987</a></li>
<li>Support <code>canEncode()</code> for <code>JAXBElement</code> in <code>Jaxb2XmlEncoder</code> <a href="https://redirect.github.com/spring-projects/spring-framework/pull/32977">#32977</a></li>
<li>AspectJ CTW aspects executed twice <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32970">#32970</a></li>
<li><code>@Valid</code> annotations on container elements for handler argument validation not supported <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32964">#32964</a></li>
<li>Add support for double backslashes to <code>StringUtils#cleanPath</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32962">#32962</a></li>
<li><code>@CacheEvict</code> condition uses wrapper comparison instead of actual objects <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32960">#32960</a></li>
<li>ConcurrentHashMap.computeIfAbsent used in AdvisedSupport can cause virtual thread pinning <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32958">#32958</a></li>
<li>Exception mapping does not work as expected when plugging in ReactorNettyClientRequestFactory into RestTemplate and RestClient <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32952">#32952</a></li>
<li><code>ReactorResourceFactory</code> not working with CRaC onRefresh checkpoint <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32945">#32945</a></li>
<li>SpEL compilation fails when indexing into an array or list with an <code>Integer</code> <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32908">#32908</a></li>
<li>SpEL compilation fails when indexing into a <code>Map</code> with a primitive <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32903">#32903</a></li>
<li>BeanUtils.copyProperties no longer copies generic type properties from a base class that has been enhanced <a href="https://redirect.github.com/spring-projects/spring-framework/issues/32888">#32888</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/spring-projects/spring-framework/commit/5356a1b1ac983c1e121d809fb54c3cb43f640f9b"><code>5356a1b</code></a> Release v6.1.10</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/f7307c9e077d3cdc2228c1ace456b0014ab83278"><code>f7307c9</code></a> Avoid recording RestClient observations twice</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/098c4b1dd73d6cfca4332de51235240aeeb56bf7"><code>098c4b1</code></a> Use Sonatype S01 token in release pipeline</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/65dbfd09b4f298a44dd49a45e8027507e03069b0"><code>65dbfd0</code></a> Defensive PersistenceExceptionTranslator bean retrieval on shutdown</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/203fa7519692a3d12a4eca73765ba6592b164fd3"><code>203fa75</code></a> Support all &quot;connection reset&quot; phrases in DisconnectedClientHelper</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/9a56a8877f5de1bce2da78ea7c6a4297970e8519"><code>9a56a88</code></a> Polishing</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/e79a9a5bff15323545e21b812f7cea8585f8eddd"><code>e79a9a5</code></a> Correct and consistent event class names in constructor javadoc</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/2c3c3831c179df3bf22edc6bcf6323631a32156e"><code>2c3c383</code></a> Consistently ignore bridge method on generated subclass for visibility purposes</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/c38e9896c7d51b35d5ff80ab498475b6190c77be"><code>c38e989</code></a> Remove use of ServletException in ModelFactory</li>
<li><a href="https://github.com/spring-projects/spring-framework/commit/3e0849a566aa21636d2b9471968c381442fce591"><code>3e0849a</code></a> Fix typo</li>
<li>Additional commits viewable in <a href="https://github.com/spring-projects/spring-framework/compare/v4.3.7.RELEASE...v6.1.10">compare view</a></li>
</ul>
</details>
<br />
